### PR TITLE
fix(minor): text for navbar items to wrap, broken linkedin link

### DIFF
--- a/src/components/contact/Contact.md
+++ b/src/components/contact/Contact.md
@@ -2,7 +2,7 @@
 
 ---
 
-### [<clrbl>LinkedIn](https://linked.com/in/jonathan-kerk)
+### [<clrbl>LinkedIn](https://linkedin.com/in/jonathan-kerk)
 
 ### [<clrog>GitHub](https://github.com/jonzxz)
 

--- a/src/components/navBar/index.css
+++ b/src/components/navBar/index.css
@@ -6,6 +6,7 @@
   position: fixed;
   height: 100%;
   width:19%;
+  word-wrap: break-word;
   margin-left:3%;
   top: 0px;
   left: 0px;


### PR DESCRIPTION
- Fixed broken link on Contact.md due to a typo
- Fixed navigation items to wrap text when port size is reduced

| Before | After |
| --- | --- |
| ![localhost_3000_ (2)](https://user-images.githubusercontent.com/59083326/206172016-81b611a0-6d83-4169-9eb6-581bfb3abef3.png) | ![localhost_3000_ (1)](https://user-images.githubusercontent.com/59083326/206172051-ab4cbe0c-9f6f-4f4a-ad2b-8c1d8f96a1f9.png) |
